### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/flexiblepower/powermatcher.png?label=ready&title=Ready)](https://waffle.io/flexiblepower/powermatcher)
 # PowerMatcher
 
 This repository contains the PowerMatcher core code and the PowerMatcher Simulation Tool. 


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/flexiblepower/powermatcher

This was requested by a real person (user THoeken) on waffle.io, we're not trying to spam you.
