### PR TITLE
Add support for unittests and code coverage reporting in Sonar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,44 @@
 apply from: rootProject.file("${bnd_cnf}/gradle/master.gradle")
 
-//Generate sonar-runner.properties containing all projects and jars
+allprojects {
+    apply plugin: 'java'
+    apply plugin: 'jacoco'
+
+	repositories {
+        jcenter()
+    }
+	
+	jacoco {
+		toolVersion = "0.7.1.201405082137"
+		reportsDir = file("$buildDir/jacoco")
+	}
+
+}
+
+/////
+ tasks.withType(Compile) {
+ options.debug = true
+ options.compilerArgs = ["-g"]
+ }
+ ////
+ 
+test {
+    jacoco {
+        append = false
+        destinationFile = file("$buildDir/jacoco/jacocoTest.exec")
+        classDumpFile = file("$buildDir/jacoco/classpathdumps")
+    }
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled true
+        csv.enabled false
+        html.destination "${buildDir}/jacocoHtml"
+    }
+}
+
+// Generate sonar-runner.properties containing all projects and jars
 task generatesonar << {
 
 	// Find all OSGI projects and only include BND projects with actual source code
@@ -18,6 +56,7 @@ task generatesonar << {
 	settingsFile << 'sonar.sources=src\n'
 	settingsFile << 'sonar.binaries=bin\n'
 	settingsFile << 'sonar.junit.reportsPath=generated/test-results\n'
+	settingsFile << 'sonar.jacoco.reportPath=generated/jacoco/test.exec\n'
 	
 	// Add all projects comma separated
 	settingsFile << 'sonar.modules='


### PR DESCRIPTION
Resolves #89 Test coverage in Sonar

Added correct unittest report output path in sonar.properties
Added support for Jacoco in gradle.build
Added correct report path for Jacoco in sonar.properties
