### PR TITLE
Proposed API change: Retrieving status of an Agent

### DIFF
--- a/net.powermatcher.api/src/net/powermatcher/api/Agent.java
+++ b/net.powermatcher.api/src/net/powermatcher/api/Agent.java
@@ -1,5 +1,9 @@
 package net.powermatcher.api;
 
+import net.powermatcher.api.data.Bid;
+import net.powermatcher.api.data.MarketBasis;
+import net.powermatcher.api.data.Price;
+
 import org.flexiblepower.context.FlexiblePowerContext;
 
 /**
@@ -9,6 +13,39 @@ import org.flexiblepower.context.FlexiblePowerContext;
  * @version 2.0
  */
 public interface Agent {
+    /**
+     * The {@link Status} object describes the current connection status of an {@link Agent}. This status can be queried
+     * through the {@link Agent#getStatus()} method and will give a snapshot of the state at that time.
+     */
+    interface Status {
+        /**
+         * @return the id of the cluster, as received from its {@link Agent} parent.
+         * @throws IllegalStateException
+         *             when the agent is not connected (see {@link #isConnected()})
+         */
+        String getClusterId();
+
+        /**
+         * @return the current {@link MarketBasis} on which this {@link Agent} is running and basing its {@link Bid}s
+         *         and {@link Price}s.
+         * @throws IllegalStateException
+         *             when the agent is not connected (see {@link #isConnected()})
+         */
+        MarketBasis getMarketBasis();
+
+        /**
+         * For a agent to be connect, the {@link #setContext(FlexiblePowerContext)} has been called and the agent has
+         * been configured with a clusterId (and usually a market basis). Only if this is <code>true</code> should the
+         * agent be used normally.
+         *
+         * For an {@link AgentEndpoint} this means that it has been connected through a {@link Session}. For a
+         * {@link MatcherEndpoint} is can be connected simply by having a {@link MarketBasis} configured (e.g. for an
+         * Auctioneer).
+         *
+         * @return <code>true</code> when the agent is connected to the cluster.
+         */
+        boolean isConnected();
+    }
 
     /**
      * @return the mandatory unique id of the {@link Agent}.
@@ -16,11 +53,10 @@ public interface Agent {
     String getAgentId();
 
     /**
-     * @return the id of the cluster, as received from its {@link Agent} parent.
-     * @throws IllegalStateException
-     *             when the agent is not connected (see {@link #isConnected()})
+     * @return The current {@link Status} of the {@link Agent}. This returns a snapshot of the state that won't change.
+     *         If used at a later time, the snapshot should be refreshed.
      */
-    String getClusterId();
+    Status getStatus();
 
     /**
      * Give the agent a reference to a {@link FlexiblePowerContext}. This should be done by the runtime bundle after the
@@ -30,16 +66,4 @@ public interface Agent {
      *            reference to the {@link FlexiblePowerContext}
      */
     void setContext(FlexiblePowerContext context);
-
-    /**
-     * For a agent to be connect, the {@link #setContext(FlexiblePowerContext)} has been called and the agent has been
-     * configured with a clusterId (and usually a market basis). Only if this is <code>true</code> should the agent be
-     * used normally.
-     *
-     * For an {@link AgentEndpoint} this means that it has been connected through a {@link Session}. For a
-     * {@link MatcherEndpoint} is can be connected simply by having a marketbasis configured (e.g. for an Auctioneer).
-     *
-     * @return <code>true</code> when the agent is connected to the cluster.
-     */
-    boolean isConnected();
 }

--- a/net.powermatcher.api/src/net/powermatcher/api/AgentEndpoint.java
+++ b/net.powermatcher.api/src/net/powermatcher/api/AgentEndpoint.java
@@ -16,12 +16,31 @@ public interface AgentEndpoint
     extends Agent {
 
     /**
+     * The {@link Status} object describes the current status and configuration of an {@link AgentEndpoint}. This status
+     * can be queried through the {@link AgentEndpoint#getStatus()} method and will give a snapshot of the state at that
+     * time.
+     */
+    interface Status
+        extends Agent.Status {
+        /**
+         * @return the current {@link Session} for the connection from this {@link AgentEndpoint} to the
+         *         {@link MatcherEndpoint}.
+         * @throws IllegalStateException
+         *             when the agent is not connected (see {@link #isConnected()})
+         */
+        Session getSession();
+    }
+
+    /**
      * @return the id of the desired parent {@link Agent}.
      */
     String getDesiredParentId();
 
+    @Override
+    Status getStatus();
+
     /**
-     * Connects this {@link AgentEndpoint} instance to a {@link MatcherEndpoint} .
+     * Connects this {@link AgentEndpoint} instance to a {@link MatcherEndpoint}.
      *
      * @param session
      *            the {@link Session} that will link this {@link AgentEndpoint} with a {@link MatcherEndpoint}.

--- a/net.powermatcher.core/src/net/powermatcher/core/BaseAgent.java
+++ b/net.powermatcher.core/src/net/powermatcher/core/BaseAgent.java
@@ -4,11 +4,8 @@ import java.util.Date;
 import java.util.Observer;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import net.powermatcher.api.Agent;
-import net.powermatcher.api.data.MarketBasis;
 import net.powermatcher.api.monitoring.AgentObserver;
 import net.powermatcher.api.monitoring.ObservableAgent;
 import net.powermatcher.api.monitoring.events.AgentEvent;
@@ -30,40 +27,6 @@ public abstract class BaseAgent
 
     protected final Logger LOGGER = LoggerFactory.getLogger(getClass());
 
-    protected final ReadWriteLock lock = new ReentrantReadWriteLock();
-    
-    /**
-     * The id of this Agent.
-     */
-    private volatile String agentId;
-
-    /**
-     * This method should always be called during activation of the agent. It sets the identifier of this agent.
-     *
-     * @param agentId
-     *            The agentId that should be used by this {@link BaseAgent}. This will be returned weth the
-     *            {@link #getAgentId()} is called.
-     *
-     * @throws IllegalArgumentException
-     *             when the agentId is null or is an empty string.
-     */
-    protected void init(String agentId) {
-        if (this.agentId != null) {
-            throw new IllegalStateException("Agent already initialized with an AgentId");
-        } else if (agentId == null || agentId.isEmpty()) {
-            throw new IllegalArgumentException("The agentId may not be null or empty");
-        }
-        this.agentId = agentId;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public String getAgentId() {
-        return agentId;
-    }
-
     protected volatile FlexiblePowerContext context;
 
     /**
@@ -71,9 +34,6 @@ public abstract class BaseAgent
      */
     @Override
     public void setContext(FlexiblePowerContext context) {
-        if (agentId == null) {
-            throw new IllegalStateException("The init method should be called first before the context is set.");
-        }
         this.context = context;
     }
 
@@ -87,80 +47,6 @@ public abstract class BaseAgent
             throw new IllegalStateException("The FlexiblePowerContext has not been set, is the PowerMatcher runtime active?");
         }
         return context.currentTime();
-    }
-
-    private volatile String clusterId;
-    private volatile MarketBasis marketBasis;
-
-    /**
-     * Configures the agent to use a specific {@link MarketBasis} and a cluster identifier.
-     *
-     * @param marketBasis
-     *            The {@link MarketBasis} that this agent should use.
-     * @param clusterId
-     *            The (locally) unique identifier for the cluster this agent is a part of.
-     */
-    protected void configure(MarketBasis marketBasis, String clusterId) {
-        if (agentId == null) {
-            throw new IllegalStateException("The init method should be called first before the agent is configured.");
-        } else if (marketBasis == null) {
-            throw new IllegalArgumentException("The MarketBasis can not be null");
-        } else if (clusterId == null) {
-            throw new IllegalArgumentException("The clusterId can not be null");
-        }
-
-        this.clusterId = clusterId;
-        this.marketBasis = marketBasis;
-    }
-
-    protected void unconfigure() {
-        clusterId = null;
-        marketBasis = null;
-    }
-
-    /**
-     * @throws IllegalStateException
-     *             When this is called before the agent is connected to the cluster.
-     */
-    @Override
-    public String getClusterId() {
-        checkConnected();
-        return clusterId;
-    }
-
-    /**
-     * @return The {@link MarketBasis} that this agent is using.
-     * @throws IllegalStateException
-     *             When this is called before the agent is connected to the cluster.
-     */
-    public MarketBasis getMarketBasis() {
-        checkConnected();
-        return marketBasis;
-    }
-
-    private void checkConnected() {
-        if (!isConnected()) {
-            StringBuilder sb = new StringBuilder();
-            sb.append("The agent [").append(agentId).append("] is not connected to the cluster. ");
-            if (context == null) {
-                sb.append("Missing FlexiblePowerContext. ");
-            }
-            if (clusterId == null) {
-                sb.append("Not connected to the cluster. ");
-            }
-            throw new IllegalStateException(sb.toString());
-        }
-    }
-
-    /**
-     * Indicates if the agent is ready. This is only true after {@link #init(String)} and
-     * {@link #configure(MarketBasis, String)} are called.
-     *
-     * @return true when the {@link #init(String)} and {@link #configure(MarketBasis, String)} methods have been called
-     */
-    @Override
-    public boolean isConnected() {
-        return context != null && clusterId != null;
     }
 
     /**

--- a/net.powermatcher.core/src/net/powermatcher/core/concentrator/Concentrator.java
+++ b/net.powermatcher.core/src/net/powermatcher/core/concentrator/Concentrator.java
@@ -117,8 +117,10 @@ public class Concentrator
     @Override
     @Deactivate
     public void deactivate() {
-        if (isConnected()) {
-            matcherEndpointDisconnected(getSession());
+        AgentEndpoint.Status currentStatus = getStatus();
+
+        if (currentStatus.isConnected()) {
+            matcherEndpointDisconnected(currentStatus.getSession());
         }
         LOGGER.info("Concentrator [{}], deactivated", config.agentId());
     }

--- a/net.powermatcher.core/src/net/powermatcher/core/concentrator/Concentrator.java
+++ b/net.powermatcher.core/src/net/powermatcher/core/concentrator/Concentrator.java
@@ -151,7 +151,7 @@ public class Concentrator
             Price price = transformPrice(priceUpdate.getPrice(), info);
             matcherPart.publishPrice(price, info.getOriginalBid());
         } catch (IllegalArgumentException ex) {
-            LOGGER.warn("Received a price update for a bid that I never sent, id: {}", priceUpdate.getBidNumber());
+            LOGGER.warn(ex.getMessage(), ex);
         }
     }
 

--- a/net.powermatcher.core/test/net/powermatcher/core/auctioneer/test/AuctioneerTest.java
+++ b/net.powermatcher.core/test/net/powermatcher/core/auctioneer/test/AuctioneerTest.java
@@ -18,8 +18,8 @@ import net.powermatcher.api.monitoring.events.AggregatedBidEvent;
 import net.powermatcher.api.monitoring.events.IncomingBidUpdateEvent;
 import net.powermatcher.api.monitoring.events.OutgoingPriceUpdateEvent;
 import net.powermatcher.core.auctioneer.Auctioneer;
-import net.powermatcher.mock.MockAgent;
 import net.powermatcher.mock.MockContext;
+import net.powermatcher.mock.MockDeviceAgent;
 import net.powermatcher.mock.SimpleSession;
 import net.powermatcher.test.helpers.PropertiesBuilder;
 
@@ -44,10 +44,10 @@ public class AuctioneerTest {
     public void setUp() {
         auctioneer = new Auctioneer();
         auctioneer.activate(new PropertiesBuilder().agentId(AUCTIONEER_ID)
-                                                  .clusterId(CLUSTER_ID)
-                                                  .marketBasis(marketBasis)
-                                                  .minTimeBetweenPriceUpdates(1000)
-                                                  .build());
+                                                   .clusterId(CLUSTER_ID)
+                                                   .marketBasis(marketBasis)
+                                                   .minTimeBetweenPriceUpdates(1000)
+                                                   .build());
 
         mockContext = new MockContext(0);
         auctioneer.setContext(mockContext);
@@ -95,13 +95,13 @@ public class AuctioneerTest {
     public void testDeactivate() {
         auctioneer.deactivate();
         try {
-            auctioneer.getClusterId();
+            auctioneer.getStatus().getClusterId();
             fail("Expected an IllegalStateException after being deactivated");
         } catch (IllegalStateException ex) {
             // Expected
         }
         try {
-            auctioneer.getMarketBasis();
+            auctioneer.getStatus().getMarketBasis();
             fail("Expected an IllegalStateException after being deactivated");
         } catch (IllegalStateException ex) {
             // Expected
@@ -110,27 +110,24 @@ public class AuctioneerTest {
 
     @Test
     public void testConnectToAgent() {
-        MockAgent agent = new MockAgent("agent1");
-        agent.setDesiredParentId(AUCTIONEER_ID);
+        MockDeviceAgent agent = new MockDeviceAgent("agent1", AUCTIONEER_ID);
         new SimpleSession(agent, auctioneer).connect();
         Session session = agent.getSession();
-        assertThat(session.getClusterId(), is(equalTo(auctioneer.getClusterId())));
+        assertThat(session.getClusterId(), is(equalTo(auctioneer.getStatus().getClusterId())));
         assertThat(session.getMarketBasis(), is(equalTo(marketBasis)));
     }
 
     @Test
     public void testAgentEndpointDisconnected() {
-        MockAgent agent = new MockAgent("agent1");
-        agent.setDesiredParentId(AUCTIONEER_ID);
+        MockDeviceAgent agent = new MockDeviceAgent("agent1", AUCTIONEER_ID);
         SimpleSession session = new SimpleSession(agent, auctioneer);
         session.connect();
         assertThat(agent.getSession(), is(notNullValue()));
-        assertThat(agent.getClusterId(), is(notNullValue()));
+        assertThat(agent.getStatus().getClusterId(), is(notNullValue()));
 
         session.disconnect();
 
         assertThat(agent.getSession(), is(nullValue()));
-        assertThat(agent.getClusterId(), is(nullValue()));
         assertThat(agent.getSession(), is(nullValue()));
     }
 
@@ -142,8 +139,7 @@ public class AuctioneerTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testupdateBidDifferentMarketBasis() {
-        MockAgent mockAgent = new MockAgent("mockAgent");
-        mockAgent.setDesiredParentId(AUCTIONEER_ID);
+        MockDeviceAgent mockAgent = new MockDeviceAgent("mockAgent", AUCTIONEER_ID);
         new SimpleSession(mockAgent, auctioneer).connect();
 
         auctioneer.handleBidUpdate(mockAgent.getSession(),
@@ -153,8 +149,7 @@ public class AuctioneerTest {
     @Test
     public void testUpdateBid() {
         String agentName = "mockAgent";
-        MockAgent mockAgent = new MockAgent(agentName);
-        mockAgent.setDesiredParentId(AUCTIONEER_ID);
+        MockDeviceAgent mockAgent = new MockDeviceAgent(agentName, AUCTIONEER_ID);
 
         AuctioneerObserver observer = new AuctioneerObserver();
         auctioneer.addObserver(observer);
@@ -173,8 +168,7 @@ public class AuctioneerTest {
     @Test
     public void testPublishPriceUpdate() {
         String agentName = "mockAgent";
-        MockAgent mockAgent = new MockAgent(agentName);
-        mockAgent.setDesiredParentId(AUCTIONEER_ID);
+        MockDeviceAgent mockAgent = new MockDeviceAgent(agentName, AUCTIONEER_ID);
 
         AuctioneerObserver observer = new AuctioneerObserver();
         auctioneer.addObserver(observer);

--- a/net.powermatcher.core/test/net/powermatcher/core/concentrator/test/ConcentratorTest.java
+++ b/net.powermatcher.core/test/net/powermatcher/core/concentrator/test/ConcentratorTest.java
@@ -15,8 +15,8 @@ import net.powermatcher.api.data.Price;
 import net.powermatcher.api.messages.BidUpdate;
 import net.powermatcher.api.messages.PriceUpdate;
 import net.powermatcher.core.concentrator.Concentrator;
-import net.powermatcher.mock.MockAgent;
 import net.powermatcher.mock.MockContext;
+import net.powermatcher.mock.MockDeviceAgent;
 import net.powermatcher.mock.MockMatcherAgent;
 import net.powermatcher.mock.SimpleSession;
 import net.powermatcher.test.helpers.PropertiesBuilder;
@@ -43,9 +43,9 @@ public class ConcentratorTest {
     @Before
     public void setUp() {
         concentrator.activate(new PropertiesBuilder().agentId(CONCENTRATOR_ID)
-                                                    .desiredParentId(AUCTIONEER_ID)
-                                                    .minTimeBetweenBidUpdates(MIN_TIME_BETWEEN_BIDS)
-                                                    .build());
+                                                     .desiredParentId(AUCTIONEER_ID)
+                                                     .minTimeBetweenBidUpdates(MIN_TIME_BETWEEN_BIDS)
+                                                     .build());
         concentrator.setContext(context);
     }
 
@@ -57,55 +57,44 @@ public class ConcentratorTest {
 
     @Test(expected = IllegalStateException.class)
     public void testConnectToAgentBeforeMatcher() {
-        Session session = new SimpleSession(new MockAgent("testAgent"), concentrator);
+        Session session = new SimpleSession(new MockDeviceAgent("testAgent", CONCENTRATOR_ID), concentrator);
         concentrator.connectToAgent(session);
     }
 
     @Test
     public void testMatcherEndpointDisconnected() {
-        MockMatcherAgent mockMatcherAgent = new MockMatcherAgent(AUCTIONEER_ID, CLUSTER_ID);
-        mockMatcherAgent.setMarketBasis(marketBasis);
-
-        MockAgent mockAgent = new MockAgent("testAgent");
-        mockAgent.setDesiredParentId(CONCENTRATOR_ID);
+        MockMatcherAgent mockMatcherAgent = new MockMatcherAgent(AUCTIONEER_ID, CLUSTER_ID, marketBasis);
+        MockDeviceAgent mockAgent = new MockDeviceAgent("testAgent", CONCENTRATOR_ID);
 
         SimpleSession topSession = new SimpleSession(concentrator, mockMatcherAgent);
         topSession.connect();
         new SimpleSession(mockAgent, concentrator).connect();
 
-        assertNotNull(mockAgent.getClusterId());
+        assertNotNull(mockAgent.getStatus().getClusterId());
 
         topSession.disconnect();
         assertNull(mockMatcherAgent.getSession());
-        assertFalse(concentrator.isConnected());
-        assertNull(mockAgent.getSession());
-        assertNull(mockAgent.getClusterId());
+        assertFalse(concentrator.getStatus().isConnected());
         assertNull(mockAgent.getSession());
     }
 
     @Test
     public void testAgentEndpointDisconnected() {
-        MockMatcherAgent mockMatcherAgent = new MockMatcherAgent(AUCTIONEER_ID, CLUSTER_ID);
-        mockMatcherAgent.setDesiredParentId("test");
-        mockMatcherAgent.setMarketBasis(marketBasis);
-        MockAgent mockAgent = new MockAgent("testAgent");
-        mockAgent.setDesiredParentId(CONCENTRATOR_ID);
+        MockMatcherAgent mockMatcherAgent = new MockMatcherAgent(AUCTIONEER_ID, CLUSTER_ID, marketBasis);
+        MockDeviceAgent mockAgent = new MockDeviceAgent("testAgent", CONCENTRATOR_ID);
 
         new SimpleSession(concentrator, mockMatcherAgent).connect();
         SimpleSession agentSession = new SimpleSession(mockAgent, concentrator);
         agentSession.connect();
 
         assertNotNull(mockMatcherAgent.getSession());
-        assertNotNull(mockAgent.getClusterId());
+        assertNotNull(mockAgent.getStatus().getClusterId());
 
         agentSession.disconnect();
 
         assertNotNull(mockMatcherAgent.getSession());
-        assertNotNull(concentrator.getClusterId(), is(CLUSTER_ID));
+        assertNotNull(concentrator.getStatus().getClusterId(), is(CLUSTER_ID));
         assertNull(mockAgent.getSession());
-        assertNull(mockAgent.getClusterId());
-        assertNull(mockAgent.getSession());
-
     }
 
     @Test(expected = IllegalStateException.class)
@@ -116,11 +105,8 @@ public class ConcentratorTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testupdateBidDifferentMarketBasis() {
-        MockMatcherAgent mockMatcherAgent = new MockMatcherAgent(AUCTIONEER_ID, CLUSTER_ID);
-        mockMatcherAgent.setDesiredParentId("test");
-        mockMatcherAgent.setMarketBasis(marketBasis);
-        MockAgent mockAgent = new MockAgent("testAgent");
-        mockAgent.setDesiredParentId(CONCENTRATOR_ID);
+        MockMatcherAgent mockMatcherAgent = new MockMatcherAgent(AUCTIONEER_ID, CLUSTER_ID, marketBasis);
+        MockDeviceAgent mockAgent = new MockDeviceAgent("testAgent", CONCENTRATOR_ID);
 
         new SimpleSession(concentrator, mockMatcherAgent).connect();
         new SimpleSession(mockAgent, concentrator).connect();
@@ -133,11 +119,8 @@ public class ConcentratorTest {
 
     @Test
     public void testUpdateBid() {
-        MockMatcherAgent mockMatcherAgent = new MockMatcherAgent(AUCTIONEER_ID, CLUSTER_ID);
-        mockMatcherAgent.setMarketBasis(marketBasis);
-        mockMatcherAgent.setDesiredParentId("test");
-        MockAgent mockAgent = new MockAgent("testAgent");
-        mockAgent.setDesiredParentId(CONCENTRATOR_ID);
+        MockMatcherAgent mockMatcherAgent = new MockMatcherAgent(AUCTIONEER_ID, CLUSTER_ID, marketBasis);
+        MockDeviceAgent mockAgent = new MockDeviceAgent("testAgent", CONCENTRATOR_ID);
 
         new SimpleSession(concentrator, mockMatcherAgent).connect();
         new SimpleSession(mockAgent, concentrator).connect();
@@ -158,11 +141,8 @@ public class ConcentratorTest {
 
     @Test
     public void testUpdatePrice() {
-        MockMatcherAgent mockMatcherAgent = new MockMatcherAgent(AUCTIONEER_ID, CLUSTER_ID);
-        mockMatcherAgent.setMarketBasis(marketBasis);
-        mockMatcherAgent.setDesiredParentId("test");
-        MockAgent mockAgent = new MockAgent("testAgent");
-        mockAgent.setDesiredParentId(CONCENTRATOR_ID);
+        MockMatcherAgent mockMatcherAgent = new MockMatcherAgent(AUCTIONEER_ID, CLUSTER_ID, marketBasis);
+        MockDeviceAgent mockAgent = new MockDeviceAgent("testAgent", CONCENTRATOR_ID);
 
         new SimpleSession(concentrator, mockMatcherAgent).connect();
         new SimpleSession(mockAgent, concentrator).connect();
@@ -183,11 +163,8 @@ public class ConcentratorTest {
 
     @Test
     public void testTiming() {
-        MockMatcherAgent mockMatcherAgent = new MockMatcherAgent(AUCTIONEER_ID, CLUSTER_ID);
-        mockMatcherAgent.setMarketBasis(marketBasis);
-        mockMatcherAgent.setDesiredParentId("test");
-        MockAgent mockAgent = new MockAgent("testAgent");
-        mockAgent.setDesiredParentId(CONCENTRATOR_ID);
+        MockMatcherAgent mockMatcherAgent = new MockMatcherAgent(AUCTIONEER_ID, CLUSTER_ID, marketBasis);
+        MockDeviceAgent mockAgent = new MockDeviceAgent("testAgent", CONCENTRATOR_ID);
 
         new SimpleSession(concentrator, mockMatcherAgent).connect();
         new SimpleSession(mockAgent, concentrator).connect();

--- a/net.powermatcher.examples/src/net/powermatcher/examples/Freezer.java
+++ b/net.powermatcher.examples/src/net/powermatcher/examples/Freezer.java
@@ -8,6 +8,7 @@ import javax.measure.Measure;
 import javax.measure.unit.SI;
 
 import net.powermatcher.api.AgentEndpoint;
+import net.powermatcher.api.data.MarketBasis;
 import net.powermatcher.api.data.PointBid;
 import net.powermatcher.api.data.Price;
 import net.powermatcher.api.data.PricePoint;
@@ -110,13 +111,15 @@ public class Freezer
      * {@inheritDoc}
      */
     void doBidUpdate() {
-        if (isConnected()) {
+        AgentEndpoint.Status currentStatus = getStatus();
+        if (currentStatus.isConnected()) {
             double demand = minimumDemand + (maximumDemand - minimumDemand)
                             * generator.nextDouble();
 
-            publishBid(new PointBid.Builder(getMarketBasis()).add(getMarketBasis().getMinimumPrice(), demand)
-                                                             .add(getMarketBasis().getMaximumPrice(), minimumDemand)
-                                                             .build());
+            MarketBasis mb = currentStatus.getMarketBasis();
+            publishBid(new PointBid.Builder(mb).add(mb.getMinimumPrice(), demand)
+                                               .add(mb.getMaximumPrice(), minimumDemand)
+                                               .build());
         }
     }
 

--- a/net.powermatcher.examples/src/net/powermatcher/examples/ObjectiveAgent.java
+++ b/net.powermatcher.examples/src/net/powermatcher/examples/ObjectiveAgent.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import net.powermatcher.api.AgentEndpoint;
 import net.powermatcher.api.data.Bid;
 import net.powermatcher.api.monitoring.AgentObserver;
 import net.powermatcher.api.monitoring.ObservableAgent;
@@ -141,18 +142,19 @@ public class ObjectiveAgent
      */
     private void handleAggregatedBid(Bid aggregatedBid) {
         LOGGER.info("Received aggregated bid: [{}] ", aggregatedBid.toArrayBid().getDemand());
-        if (isConnected()) {
+        AgentEndpoint.Status currentStatus = getStatus();
+        if (currentStatus.isConnected()) {
             // Can the cluster produce more than the asked amount of energy?
             if (aggregatedBid.getMinimumDemand() < -1000) {
                 // The cluster has the ability to produce config.flexibilityToUse() Watts
                 // We ask the cluster to produce config.flexibilityToUse() by demanding this amount of energy in an
                 // non flexible bid
                 LOGGER.info("Asking the cluster to produce 1000W");
-                publishBid(Bid.flatDemand(getMarketBasis(), 1000));
+                publishBid(Bid.flatDemand(currentStatus.getMarketBasis(), 1000));
             } else {
                 // We don't ask anything from the cluster, we send a must off bid
                 LOGGER.info("Not asking the cluster to produce 1000W");
-                publishBid(Bid.flatDemand(getMarketBasis(), 0));
+                publishBid(Bid.flatDemand(currentStatus.getMarketBasis(), 0));
             }
         }
     }

--- a/net.powermatcher.examples/src/net/powermatcher/examples/PVPanelAgent.java
+++ b/net.powermatcher.examples/src/net/powermatcher/examples/PVPanelAgent.java
@@ -112,9 +112,10 @@ public class PVPanelAgent
      * {@inheritDoc}
      */
     void doBidUpdate() {
-        if (isConnected()) {
+        AgentEndpoint.Status currentStatus = getStatus();
+        if (currentStatus.isConnected()) {
             double demand = minimumDemand + (maximumDemand - minimumDemand) * generator.nextDouble();
-            publishBid(Bid.flatDemand(getMarketBasis(), demand));
+            publishBid(Bid.flatDemand(currentStatus.getMarketBasis(), demand));
         }
     }
 

--- a/net.powermatcher.monitoring.csv/test/net/powermatcher/monitoring/csv/test/ObservableAgentTest.java
+++ b/net.powermatcher.monitoring.csv/test/net/powermatcher/monitoring/csv/test/ObservableAgentTest.java
@@ -11,7 +11,7 @@ import net.powermatcher.api.messages.PriceUpdate;
 import net.powermatcher.api.monitoring.ObservableAgent;
 import net.powermatcher.api.monitoring.events.AgentEvent;
 import net.powermatcher.api.monitoring.events.IncomingPriceUpdateEvent;
-import net.powermatcher.mock.MockAgent;
+import net.powermatcher.mock.MockDeviceAgent;
 import net.powermatcher.mock.MockObserver;
 
 import org.junit.Test;
@@ -28,7 +28,7 @@ public class ObservableAgentTest {
     public void oneObserverTest() {
         MockObserver observer = new MockObserver();
 
-        MockAgent observable = new MockAgent("agentId");
+        MockDeviceAgent observable = new MockDeviceAgent("agentId", "matcherId");
         observable.addObserver(observer);
         observable.publishEvent(createDummyEvent());
 
@@ -40,7 +40,7 @@ public class ObservableAgentTest {
         MockObserver observer1 = new MockObserver();
         MockObserver observer2 = new MockObserver();
 
-        MockAgent observable = new MockAgent("agentId");
+        MockDeviceAgent observable = new MockDeviceAgent("agentId", "matcherId");
         observable.addObserver(observer1);
         observable.addObserver(observer2);
         observable.publishEvent(createDummyEvent());
@@ -54,7 +54,7 @@ public class ObservableAgentTest {
         MockObserver observer1 = new MockObserver();
         MockObserver observer2 = new MockObserver();
 
-        MockAgent observable = new MockAgent("agentId");
+        MockDeviceAgent observable = new MockDeviceAgent("agentId", "matcherId");
         observable.addObserver(observer1);
         observable.addObserver(observer2);
         observable.removeObserver(observer2);
@@ -68,7 +68,7 @@ public class ObservableAgentTest {
     public void duplicateRemoveObserversTest() {
         MockObserver observer1 = new MockObserver();
 
-        MockAgent observable = new MockAgent("agentId");
+        MockDeviceAgent observable = new MockDeviceAgent("agentId", "matcherId");
         observable.addObserver(observer1);
         observable.removeObserver(observer1);
         observable.removeObserver(observer1);
@@ -76,7 +76,7 @@ public class ObservableAgentTest {
 
     @Test
     public void noObserversTest() {
-        MockAgent observable = new MockAgent("agentId");
+        MockDeviceAgent observable = new MockDeviceAgent("agentId", "matcherId");
 
         MockObserver observer1 = new MockObserver();
         observable.addObserver(observer1);

--- a/net.powermatcher.peakshaving/test/net/powermatcher/peakshaving/test/PeakShavingConcentratorTest.java
+++ b/net.powermatcher.peakshaving/test/net/powermatcher/peakshaving/test/PeakShavingConcentratorTest.java
@@ -8,8 +8,8 @@ import net.powermatcher.api.data.Bid;
 import net.powermatcher.api.data.MarketBasis;
 import net.powermatcher.api.data.Price;
 import net.powermatcher.api.messages.PriceUpdate;
-import net.powermatcher.mock.MockAgent;
 import net.powermatcher.mock.MockContext;
+import net.powermatcher.mock.MockDeviceAgent;
 import net.powermatcher.mock.MockMatcherAgent;
 import net.powermatcher.mock.SimpleSession;
 import net.powermatcher.peakshaving.PeakShavingConcentrator;
@@ -32,21 +32,18 @@ public class PeakShavingConcentratorTest {
 
     private final MockContext context = new MockContext(0);
 
-    private final MockMatcherAgent matcher = new MockMatcherAgent(AUCTIONEER_ID, CLUSTER_ID);
+    private final MockMatcherAgent matcher = new MockMatcherAgent(AUCTIONEER_ID, CLUSTER_ID, marketBasis);
     private final PeakShavingConcentrator peakShavingConcentrator = new PeakShavingConcentrator();
-    private final MockAgent deviceAgent = new MockAgent(DEVICE_AGENT_ID);
+    private final MockDeviceAgent deviceAgent = new MockDeviceAgent(DEVICE_AGENT_ID, CONCENTRATOR_NAME);
 
     public void setUp(double floor, double ceiling) throws Exception {
         peakShavingConcentrator.activate(new PropertiesBuilder().agentId(CONCENTRATOR_NAME)
-                                                               .desiredParentId(AUCTIONEER_ID)
-                                                               .minTimeBetweenBidUpdates(1000)
-                                                               .add("floor", floor)
-                                                               .add("ceiling", ceiling)
-                                                               .build());
+                                                                .desiredParentId(AUCTIONEER_ID)
+                                                                .minTimeBetweenBidUpdates(1000)
+                                                                .add("floor", floor)
+                                                                .add("ceiling", ceiling)
+                                                                .build());
         peakShavingConcentrator.setContext(context);
-
-        // Set the market basis for the matcher
-        matcher.setMarketBasis(marketBasis);
 
         // Connect the 3 parts to each other
         new SimpleSession(peakShavingConcentrator, matcher).connect();

--- a/net.powermatcher.remote.websockets/src/net/powermatcher/remote/websockets/client/WebsocketClient.java
+++ b/net.powermatcher.remote.websockets/src/net/powermatcher/remote/websockets/client/WebsocketClient.java
@@ -200,16 +200,6 @@ public class WebsocketClient
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * This specific implementation checks to see if the websocket is open.
-     */
-    @Override
-    public boolean isConnected() {
-        return super.isConnected() && isRemoteConnected();
-    }
-
-    /**
      * Determines whether the Websocket is connected.
      *
      * @return true when connected, false otherwise
@@ -246,7 +236,7 @@ public class WebsocketClient
             PmJsonSerializer serializer = new PmJsonSerializer();
             PmMessage pmMessage = serializer.deserialize(message);
 
-            if (!isConnected()) {
+            if (!getStatus().isConnected()) {
                 if (pmMessage.getPayloadType() == PayloadType.CLUSTERINFO) {
                     // Sync marketbasis and clusterid with local session, for new
                     // connections
@@ -302,7 +292,7 @@ public class WebsocketClient
         PmJsonSerializer serializer = new PmJsonSerializer();
         String message = serializer.serializeBidUpdate(update);
 
-        if (isConnected()) {
+        if (isRemoteConnected()) {
             try {
                 remoteSession.getRemote().sendString(message);
                 LOGGER.debug("Sent bid update to server {}", update);

--- a/net.powermatcher.runtime/src/net/powermatcher/runtime/SessionImpl.java
+++ b/net.powermatcher.runtime/src/net/powermatcher/runtime/SessionImpl.java
@@ -20,7 +20,7 @@ public class SessionImpl
     private final AgentEndpoint agentEndpoint;
     private final MatcherEndpoint matcherEndpoint;
     private final PotentialSession potentialSession;
-    private final String clusterId;
+    private final String agentId, matcherId, clusterId;
     private MarketBasis marketBasis;
 
     private volatile boolean connected;
@@ -30,18 +30,22 @@ public class SessionImpl
         this.agentEndpoint = agentEndpoint;
         this.matcherEndpoint = matcherEndpoint;
         this.potentialSession = potentialSession;
-        clusterId = matcherEndpoint.getClusterId();
+
+        agentId = agentEndpoint.getAgentId();
+        matcherId = matcherEndpoint.getAgentId();
+        clusterId = matcherEndpoint.getStatus().getClusterId();
+
         connected = false;
     }
 
     @Override
     public String getAgentId() {
-        return agentEndpoint.getAgentId();
+        return agentId;
     }
 
     @Override
     public String getMatcherId() {
-        return matcherEndpoint.getAgentId();
+        return matcherId;
     }
 
     @Override
@@ -70,9 +74,7 @@ public class SessionImpl
 
     void setConnected() {
         if (marketBasis == null) {
-            throw new IllegalStateException("No MarketBasis has been set by the matcher ["
-                                            + matcherEndpoint.getAgentId()
-                                            + "]");
+            throw new IllegalStateException("No MarketBasis has been set by the matcher [" + matcherId + "]");
         }
         connected = true;
     }
@@ -82,9 +84,7 @@ public class SessionImpl
         if (connected) {
             agentEndpoint.handlePriceUpdate(priceUpdate);
         } else {
-            LOGGER.debug("Sending a price update while not connected from agent ["
-                         + matcherEndpoint.getAgentId()
-                         + "]");
+            LOGGER.debug("Sending a price update while not connected from agent [" + agentId + "]");
         }
     }
 
@@ -93,9 +93,7 @@ public class SessionImpl
         if (connected) {
             matcherEndpoint.handleBidUpdate(this, bidUpdate);
         } else {
-            LOGGER.debug("Sending a bid update while not connected from agent ["
-                         + agentEndpoint.getAgentId()
-                         + "]");
+            LOGGER.debug("Sending a bid update while not connected from agent [" + agentId + "]");
         }
     }
 

--- a/net.powermatcher.runtime/test/net/powermatcher/runtime/sessions/test/SessionManagerTest.java
+++ b/net.powermatcher.runtime/test/net/powermatcher/runtime/sessions/test/SessionManagerTest.java
@@ -8,8 +8,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import net.powermatcher.api.Session;
 import net.powermatcher.api.data.MarketBasis;
-import net.powermatcher.mock.MockAgent;
 import net.powermatcher.mock.MockContext;
+import net.powermatcher.mock.MockDeviceAgent;
 import net.powermatcher.mock.MockMatcherAgent;
 import net.powermatcher.runtime.SessionManager;
 
@@ -36,18 +36,16 @@ public class SessionManagerTest {
 
     private SessionManager sessionManager;
     private MockMatcherAgent auctioneer;
-    private MockAgent testAgent;
+    private MockDeviceAgent testAgent;
 
     @Before
     public void setUp() {
-        auctioneer = new MockMatcherAgent(AUCTIONEER_NAME, CLUSTER_ID);
-        auctioneer.setMarketBasis(new MarketBasis("something", "YYY", 10, 0, 1));
+        auctioneer = new MockMatcherAgent(AUCTIONEER_NAME, CLUSTER_ID, new MarketBasis("something", "YYY", 10, 0, 1));
         auctioneer.setContext(new MockContext(0));
 
         sessionManager = new SessionManager();
 
-        testAgent = new MockAgent(AGENT_ID);
-        testAgent.setDesiredParentId("auctioneer");
+        testAgent = new MockDeviceAgent(AGENT_ID, "auctioneer");
     }
 
     @After
@@ -71,8 +69,7 @@ public class SessionManagerTest {
         // test if session is the same after adding a new agent
         int hashCode = agentSession.hashCode();
 
-        MockAgent agent2 = new MockAgent(AGENT_ID);
-        agent2.setDesiredParentId(AUCTIONEER_NAME);
+        MockDeviceAgent agent2 = new MockDeviceAgent(AGENT_ID, AUCTIONEER_NAME);
 
         sessionManager.addAgentEndpoint(agent2);
         int newCode = testAgent.getSession().hashCode();

--- a/net.powermatcher.test.helpers/src/net/powermatcher/mock/MockAgent.java
+++ b/net.powermatcher.test.helpers/src/net/powermatcher/mock/MockAgent.java
@@ -1,157 +1,25 @@
 package net.powermatcher.mock;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Observer;
-import java.util.Set;
-import java.util.concurrent.CopyOnWriteArraySet;
-
 import net.powermatcher.api.Agent;
-import net.powermatcher.api.AgentEndpoint;
-import net.powermatcher.api.Session;
-import net.powermatcher.api.data.Bid;
-import net.powermatcher.api.messages.BidUpdate;
-import net.powermatcher.api.messages.PriceUpdate;
-import net.powermatcher.api.monitoring.AgentObserver;
-import net.powermatcher.api.monitoring.ObservableAgent;
-import net.powermatcher.api.monitoring.events.AgentEvent;
 
 import org.flexiblepower.context.FlexiblePowerContext;
 
-/**
- *
- * @author FAN
- * @version 2.0
- */
-public class MockAgent
-    implements Agent, AgentEndpoint, ObservableAgent {
-
-    private final Map<String, Object> agentProperties;
-    private PriceUpdate lastPriceUpdate;
-    protected Session session;
-    private String desiredParentId;
-
-    /**
-     * Collection of {@link Observer} services.
-     */
-    private final Set<AgentObserver> observers = new CopyOnWriteArraySet<AgentObserver>();
+public abstract class MockAgent
+    implements Agent {
+    private final String agentId;
+    protected FlexiblePowerContext context;
 
     public MockAgent(String agentId) {
-        agentProperties = new HashMap<String, Object>();
-        agentProperties.put("agentId", agentId);
+        this.agentId = agentId;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void connectToMatcher(Session session) {
-        this.session = session;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void matcherEndpointDisconnected(Session session) {
-        this.session = null;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void handlePriceUpdate(PriceUpdate priceUpdate) {
-        lastPriceUpdate = priceUpdate;
-    }
-
-    public void sendBid(Bid bid, int bidNumber) {
-        session.updateBid(new BidUpdate(bid, bidNumber));
-    }
-
-    public void sendBid(BidUpdate bidUpdate) {
-        session.updateBid(bidUpdate);
-    }
-
-    /**
-     * @return the current value of lastPriceUpdate.
-     */
-    public PriceUpdate getLastPriceUpdate() {
-        return lastPriceUpdate;
-    }
-
-    /**
-     * @return the current value of agentProperties.
-     */
-    public Map<String, Object> getAgentProperties() {
-        return agentProperties;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String getAgentId() {
-        return (String) agentProperties.get("agentId");
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public String getClusterId() {
-        return session == null ? null : session.getClusterId();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public String getDesiredParentId() {
-        return desiredParentId;
-    }
-
-    public void setDesiredParentId(String desiredParentId) {
-        this.desiredParentId = desiredParentId;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void addObserver(AgentObserver observer) {
-        observers.add(observer);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void removeObserver(AgentObserver observer) {
-        observers.remove(observer);
-    }
-
-    /**
-     * @return the current value of session.
-     */
-    public Session getSession() {
-        return session;
-    }
-
-    public void publishEvent(AgentEvent event) {
-        for (AgentObserver observer : observers) {
-            observer.handleAgentEvent(event);
-        }
+        return agentId;
     }
 
     @Override
     public void setContext(FlexiblePowerContext context) {
-        // TODO Auto-generated method stub
-
-    }
-
-    @Override
-    public boolean isConnected() {
-        return session != null;
+        this.context = context;
     }
 }

--- a/net.powermatcher.test.helpers/src/net/powermatcher/mock/MockDeviceAgent.java
+++ b/net.powermatcher.test.helpers/src/net/powermatcher/mock/MockDeviceAgent.java
@@ -1,0 +1,95 @@
+package net.powermatcher.mock;
+
+import net.powermatcher.api.AgentEndpoint;
+import net.powermatcher.api.Session;
+import net.powermatcher.api.data.Bid;
+import net.powermatcher.api.data.MarketBasis;
+import net.powermatcher.api.messages.BidUpdate;
+import net.powermatcher.api.messages.PriceUpdate;
+
+/**
+ *
+ * @author FAN
+ * @version 2.0
+ */
+public class MockDeviceAgent
+    extends MockObservableAgent
+    implements AgentEndpoint {
+
+    private final String desiredParentId;
+    protected Session session;
+    private PriceUpdate lastPriceUpdate;
+
+    public MockDeviceAgent(String agentId, String desiredParentId) {
+        super(agentId);
+        this.desiredParentId = desiredParentId;
+    }
+
+    @Override
+    public String getDesiredParentId() {
+        return desiredParentId;
+    }
+
+    @Override
+    public AgentEndpoint.Status getStatus() {
+        final Session session = this.session;
+        return new AgentEndpoint.Status() {
+            @Override
+            public boolean isConnected() {
+                return session != null;
+            }
+
+            @Override
+            public MarketBasis getMarketBasis() {
+                return session.getMarketBasis();
+            }
+
+            @Override
+            public String getClusterId() {
+                return session.getClusterId();
+            }
+
+            @Override
+            public Session getSession() {
+                return session;
+            }
+        };
+    }
+
+    @Override
+    public void connectToMatcher(Session session) {
+        this.session = session;
+    }
+
+    @Override
+    public void matcherEndpointDisconnected(Session session) {
+        this.session = null;
+    }
+
+    @Override
+    public void handlePriceUpdate(PriceUpdate priceUpdate) {
+        lastPriceUpdate = priceUpdate;
+    }
+
+    public void sendBid(Bid bid, int bidNumber) {
+        session.updateBid(new BidUpdate(bid, bidNumber));
+    }
+
+    public void sendBid(BidUpdate bidUpdate) {
+        session.updateBid(bidUpdate);
+    }
+
+    /**
+     * @return the current value of session.
+     */
+    public Session getSession() {
+        return session;
+    }
+
+    /**
+     * @return the current value of lastPriceUpdate.
+     */
+    public PriceUpdate getLastPriceUpdate() {
+        return lastPriceUpdate;
+    }
+}

--- a/net.powermatcher.test.helpers/src/net/powermatcher/mock/MockObservableAgent.java
+++ b/net.powermatcher.test.helpers/src/net/powermatcher/mock/MockObservableAgent.java
@@ -1,0 +1,34 @@
+package net.powermatcher.mock;
+
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+import net.powermatcher.api.monitoring.AgentObserver;
+import net.powermatcher.api.monitoring.ObservableAgent;
+import net.powermatcher.api.monitoring.events.AgentEvent;
+
+public abstract class MockObservableAgent
+    extends MockAgent
+    implements ObservableAgent {
+    private final Set<AgentObserver> observers = new CopyOnWriteArraySet<AgentObserver>();
+
+    public MockObservableAgent(String agentId) {
+        super(agentId);
+    }
+
+    @Override
+    public void addObserver(AgentObserver observer) {
+        observers.add(observer);
+    }
+
+    @Override
+    public void removeObserver(AgentObserver observer) {
+        observers.remove(observer);
+    }
+
+    public void publishEvent(AgentEvent event) {
+        for (AgentObserver observer : observers) {
+            observer.handleAgentEvent(event);
+        }
+    }
+}

--- a/net.powermatcher.test.helpers/src/net/powermatcher/mock/SimpleSession.java
+++ b/net.powermatcher.test.helpers/src/net/powermatcher/mock/SimpleSession.java
@@ -58,7 +58,7 @@ public class SimpleSession
 
     @Override
     public String getClusterId() {
-        return matcher.getClusterId();
+        return matcher.getStatus().getClusterId();
     }
 
     @Override

--- a/net.powermatcher.test.helpers/src/net/powermatcher/test/helpers/TestClusterHelper.java
+++ b/net.powermatcher.test.helpers/src/net/powermatcher/test/helpers/TestClusterHelper.java
@@ -13,20 +13,20 @@ import net.powermatcher.api.data.ArrayBid;
 import net.powermatcher.api.data.MarketBasis;
 import net.powermatcher.api.data.Price;
 import net.powermatcher.api.messages.PriceUpdate;
-import net.powermatcher.mock.MockAgent;
 import net.powermatcher.mock.MockContext;
+import net.powermatcher.mock.MockDeviceAgent;
 import net.powermatcher.mock.MockMatcherAgent;
 import net.powermatcher.mock.SimpleSession;
 
 public class TestClusterHelper
-    implements Closeable, Iterable<MockAgent> {
+    implements Closeable, Iterable<MockDeviceAgent> {
     public static final MarketBasis DEFAULT_MB = new MarketBasis("electricity", "EUR", 11, 0, 10);
 
     private final AtomicInteger idGenerator;
 
     private final MockContext context;
 
-    private final List<MockAgent> agents;
+    private final List<MockDeviceAgent> agents;
     private final List<SimpleSession> sessions;
 
     private final MarketBasis marketBasis;
@@ -44,7 +44,7 @@ public class TestClusterHelper
 
         context = new MockContext(0);
 
-        agents = new ArrayList<MockAgent>();
+        agents = new ArrayList<MockDeviceAgent>();
         sessions = new ArrayList<SimpleSession>();
 
         this.marketBasis = marketBasis;
@@ -55,16 +55,15 @@ public class TestClusterHelper
         }
     }
 
-    public MockAgent addAgent() {
+    public MockDeviceAgent addAgent() {
         return addAgents(1).get(0);
     }
 
-    public List<MockAgent> addAgents(int nrOfAgents) {
-        List<MockAgent> newAgents = new ArrayList<MockAgent>(nrOfAgents);
+    public List<MockDeviceAgent> addAgents(int nrOfAgents) {
+        List<MockDeviceAgent> newAgents = new ArrayList<MockDeviceAgent>(nrOfAgents);
         for (int ix = 0; ix < nrOfAgents; ix++) {
             String agentId = "agent" + idGenerator.incrementAndGet();
-            MockAgent newAgent = new MockAgent(agentId);
-            newAgent.setDesiredParentId(matcher.getAgentId());
+            MockDeviceAgent newAgent = new MockDeviceAgent(agentId, matcher.getAgentId());
             agents.add(newAgent);
             newAgents.add(newAgent);
 
@@ -94,7 +93,7 @@ public class TestClusterHelper
         Price price = new Price(marketBasis, Math.random() * marketBasis.getMaximumPrice());
         matcher.publishPrice(new PriceUpdate(price, matcher.getLastReceivedBid().getBidNumber()));
         for (int i = 0; i < expectedIds.length; i++) {
-            MockAgent agent = getAgent(i);
+            MockDeviceAgent agent = getAgent(i);
             if (expectedIds[i] < 0) {
                 if (agent.getLastPriceUpdate() != null) {
                     throw new AssertionError("Last price update of agent " + i + " is not null");
@@ -121,7 +120,7 @@ public class TestClusterHelper
         agents.clear();
     }
 
-    public MockAgent getAgent(int ix) {
+    public MockDeviceAgent getAgent(int ix) {
         if (agents.size() <= ix) {
             addAgents(agents.size() - ix + 1);
         }
@@ -138,7 +137,7 @@ public class TestClusterHelper
 
     public List<PriceUpdate> getPriceUpdates() {
         List<PriceUpdate> updates = new ArrayList<PriceUpdate>(agents.size());
-        for (MockAgent agent : agents) {
+        for (MockDeviceAgent agent : agents) {
             updates.add(agent.getLastPriceUpdate());
         }
         return updates;
@@ -158,7 +157,7 @@ public class TestClusterHelper
     }
 
     @Override
-    public Iterator<MockAgent> iterator() {
+    public Iterator<MockDeviceAgent> iterator() {
         return Collections.unmodifiableList(agents).iterator();
     }
 

--- a/net.powermatcher.test.osgi/src/net/powermatcher/test/osgi/SessionManagerTests.java
+++ b/net.powermatcher.test.osgi/src/net/powermatcher/test/osgi/SessionManagerTests.java
@@ -68,7 +68,7 @@ public class SessionManagerTests
             context.submit(new Runnable() {
                 @Override
                 public void run() {
-                    publishBid(Bid.flatDemand(getMarketBasis(), Math.random() * 100));
+                    publishBid(Bid.flatDemand(getStatus().getMarketBasis(), Math.random() * 100));
                 }
             });
         }

--- a/net.powermatcher.test.osgi/src/net/powermatcher/test/osgi/SessionManagerTests.java
+++ b/net.powermatcher.test.osgi/src/net/powermatcher/test/osgi/SessionManagerTests.java
@@ -37,6 +37,7 @@ public class SessionManagerTests
 
         public TestAgent(BundleContext bundleContext) {
             init("testagent-" + agentCounter.incrementAndGet(), MATCHER_ID);
+            LOGGER.debug("Initialized agent with id {}", getAgentId());
             serviceRegistration = bundleContext.registerService(AgentEndpoint.class, this, null);
         }
 
@@ -65,6 +66,9 @@ public class SessionManagerTests
         @Override
         public synchronized void connectToMatcher(Session session) {
             super.connectToMatcher(session);
+            if (context == null) {
+                LOGGER.error("Context is really null of agent {}", getAgentId());
+            }
             context.submit(new Runnable() {
                 @Override
                 public void run() {
@@ -89,7 +93,7 @@ public class SessionManagerTests
 
         public TestMatcher(BundleContext bundleContext) {
             init(MATCHER_ID);
-            configure(MB, "testcluster", 0);
+            configure(MB, "testcluster", 100);
             serviceRegistration = bundleContext.registerService(MatcherEndpoint.class, this, null);
         }
 
@@ -162,10 +166,11 @@ public class SessionManagerTests
     }
 
     public void testConcurrent() throws InterruptedException {
+        // for (int runNr = 1; runNr < 250; runNr++) {
+        // LOGGER.info("Run number {}", runNr);
         TestMatcher testMatcher = new TestMatcher(bundleContext);
-
         List<AgentCreator> creators = new ArrayList<SessionManagerTests.AgentCreator>();
-        int THREAD_COUNT = 20, AGENTS_PER_THREAD = 20;
+        int THREAD_COUNT = 25, AGENTS_PER_THREAD = 25;
         for (int ix = 0; ix < THREAD_COUNT; ix++) {
             creators.add(new AgentCreator(bundleContext, AGENTS_PER_THREAD));
         }
@@ -178,7 +183,7 @@ public class SessionManagerTests
         }
 
         assertEquals("Some of the agents did not receive a price update", 0, totalFailed);
-
         testMatcher.close();
+        // }
     }
 }

--- a/net.powermatcher.test/test/net/powermatcher/integration/auctioneer/AuctioneerResilienceTest.java
+++ b/net.powermatcher.test/test/net/powermatcher/integration/auctioneer/AuctioneerResilienceTest.java
@@ -11,7 +11,7 @@ import net.powermatcher.integration.base.ResilienceTest;
 import net.powermatcher.integration.util.AuctioneerWrapper;
 import net.powermatcher.integration.util.CsvBidReader;
 import net.powermatcher.integration.util.CsvExpectedResultsReader;
-import net.powermatcher.mock.MockAgent;
+import net.powermatcher.mock.MockDeviceAgent;
 import net.powermatcher.test.helpers.PropertiesBuilder;
 import net.powermatcher.test.helpers.TestClusterHelper;
 
@@ -55,7 +55,7 @@ public class AuctioneerResilienceTest
         cluster.performTasks();
 
         // Verify the price received by the agents
-        for (MockAgent agent : cluster) {
+        for (MockDeviceAgent agent : cluster) {
             assertEquals(expPrice, agent.getLastPriceUpdate().getPrice().toPriceStep().toPrice().getPriceValue(), 0);
         }
     }

--- a/net.powermatcher.test/test/net/powermatcher/integration/bids/BidResilienceTest.java
+++ b/net.powermatcher.test/test/net/powermatcher/integration/bids/BidResilienceTest.java
@@ -11,7 +11,7 @@ import net.powermatcher.integration.util.AuctioneerWrapper;
 import net.powermatcher.integration.util.ConcentratorWrapper;
 import net.powermatcher.integration.util.CsvBidReader;
 import net.powermatcher.integration.util.CsvExpectedResultsReader;
-import net.powermatcher.mock.MockAgent;
+import net.powermatcher.mock.MockDeviceAgent;
 import net.powermatcher.mock.MockContext;
 import net.powermatcher.test.helpers.PropertiesBuilder;
 import net.powermatcher.test.helpers.TestClusterHelper;
@@ -79,7 +79,7 @@ public class BidResilienceTest
         double expPrice = resultsReader.getEquilibriumPrice();
 
         // Verify the price received by the agents
-        for (MockAgent agent : cluster) {
+        for (MockDeviceAgent agent : cluster) {
             assertEquals(expPrice, agent.getLastPriceUpdate().getPrice().getPriceValue(), 0);
         }
     }

--- a/net.powermatcher.test/test/net/powermatcher/integration/bids/SendReceivePriceTestCPF1.java
+++ b/net.powermatcher.test/test/net/powermatcher/integration/bids/SendReceivePriceTestCPF1.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 import java.util.zip.DataFormatException;
 
 import net.powermatcher.api.messages.PriceUpdate;
-import net.powermatcher.mock.MockAgent;
+import net.powermatcher.mock.MockDeviceAgent;
 
 import org.junit.Test;
 
@@ -54,7 +54,7 @@ public class SendReceivePriceTestCPF1
         // The bidnumber should be zero, since the original bid has a bidnumber
         // of 0
         int bidNumber = 1;
-        for (MockAgent agent : cluster) {
+        for (MockDeviceAgent agent : cluster) {
             assertEquals(priceUpdate.getPrice(), agent.getLastPriceUpdate().getPrice());
             assertEquals(bidNumber++, agent.getLastPriceUpdate().getBidNumber());
         }

--- a/net.powermatcher.test/test/net/powermatcher/integration/bids/SendReceivePriceTestCPQ1.java
+++ b/net.powermatcher.test/test/net/powermatcher/integration/bids/SendReceivePriceTestCPQ1.java
@@ -12,7 +12,7 @@ import java.util.zip.DataFormatException;
 
 import net.powermatcher.api.data.Price;
 import net.powermatcher.api.messages.PriceUpdate;
-import net.powermatcher.mock.MockAgent;
+import net.powermatcher.mock.MockDeviceAgent;
 
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -287,7 +287,7 @@ public class SendReceivePriceTestCPQ1
         auctioneer.publishPrice(priceUpdate);
 
         // Verify the price received by the agents
-        for (MockAgent agent : cluster) {
+        for (MockDeviceAgent agent : cluster) {
             assertEquals(price.getPriceValue(), agent.getLastPriceUpdate().getPrice().getPriceValue(), 0);
         }
     }

--- a/net.powermatcher.test/test/net/powermatcher/integration/concentrator/ConcentratorResilienceTest.java
+++ b/net.powermatcher.test/test/net/powermatcher/integration/concentrator/ConcentratorResilienceTest.java
@@ -11,7 +11,7 @@ import net.powermatcher.integration.base.ResilienceTest;
 import net.powermatcher.integration.util.ConcentratorWrapper;
 import net.powermatcher.integration.util.CsvBidReader;
 import net.powermatcher.integration.util.CsvExpectedResultsReader;
-import net.powermatcher.mock.MockAgent;
+import net.powermatcher.mock.MockDeviceAgent;
 import net.powermatcher.mock.MockMatcherAgent;
 import net.powermatcher.test.helpers.PropertiesBuilder;
 import net.powermatcher.test.helpers.TestClusterHelper;
@@ -42,12 +42,11 @@ public class ConcentratorResilienceTest
         MarketBasis marketBasis = resultsReader.getMarketBasis();
         concentrator = new ConcentratorWrapper();
         concentrator.activate(new PropertiesBuilder().agentId(CONCENTRATOR_NAME)
-                                                    .desiredParentId(MATCHERAGENTNAME)
-                                                    .minTimeBetweenBidUpdates(1000)
-                                                    .build());
+                                                     .desiredParentId(MATCHERAGENTNAME)
+                                                     .minTimeBetweenBidUpdates(1000)
+                                                     .build());
 
-        auctioneer = new MockMatcherAgent(MATCHERAGENTNAME, "testCluster");
-        auctioneer.setMarketBasis(marketBasis);
+        auctioneer = new MockMatcherAgent(MATCHERAGENTNAME, "testCluster", marketBasis);
 
         cluster = new TestClusterHelper(marketBasis, concentrator);
         cluster.connect(concentrator, auctioneer);
@@ -66,7 +65,7 @@ public class ConcentratorResilienceTest
         double expPrice = resultsReader.getEquilibriumPrice();
 
         // Verify the price received by the agents
-        for (MockAgent agent : cluster) {
+        for (MockDeviceAgent agent : cluster) {
             assertNotNull("agent " + agent.getAgentId() + " did not receive a price update", agent.getLastPriceUpdate());
             assertEquals(expPrice, agent.getLastPriceUpdate().getPrice().getPriceValue(), 0);
         }

--- a/net.powermatcher.test/test/net/powermatcher/integration/concentrator/ConcentratorTest.java
+++ b/net.powermatcher.test/test/net/powermatcher/integration/concentrator/ConcentratorTest.java
@@ -35,15 +35,14 @@ public class ConcentratorTest {
         // Concentrator to be tested
         concentrator = new Concentrator();
         concentrator.activate(new PropertiesBuilder().agentId(CONCENTRATOR_NAME)
-                                                    .desiredParentId(AUCTIONEER_NAME)
-                                                    .minTimeBetweenBidUpdates(1000)
-                                                    .build());
+                                                     .desiredParentId(AUCTIONEER_NAME)
+                                                     .minTimeBetweenBidUpdates(1000)
+                                                     .build());
 
         cluster = new TestClusterHelper(concentrator);
 
         // Matcher
-        matcher = new MockMatcherAgent(AUCTIONEER_NAME, "testCluster");
-        matcher.setMarketBasis(TestClusterHelper.DEFAULT_MB);
+        matcher = new MockMatcherAgent(AUCTIONEER_NAME, "testCluster", TestClusterHelper.DEFAULT_MB);
 
         cluster.connect(concentrator, matcher);
     }


### PR DESCRIPTION
This change is needed to make development of agents easier. To get all the concurrent tests running, a lot of locking was needed, because the state of the agent (whether it is connected or not) could change during any function (e.g. when an auctioneer or concentrator is removed). But because locking is hard to get right (and prone to lead to deadlocks) I propose that we can retrieve a snapshot of the state of the agent that can be used during the execution of a function.

For example, quite a few times we have the block that used this kind of pattern

```
if(isConnected()) {
  // Do something with the marketbasis or clusterId
  getMarketBasis();
  getClusterId();
}
```

This code could fail if the agent is disconnected after the if-statement (you could get an IllegalStateException if you would call getMarketBasis() or getClusterId()).

What I propose now is the following:

```
Agent.Status currentStatus = getStatus();
if(currentStatus.isConnected()) {
  // Do something with the marketbasis or clusterId and get them like:
  currentStatus.getMarketBasis();
  currentStatus.getClusterId();
}
```

This way you are guaranteed that the marketbasis and clusterId is valid. And if you send a new bid while you were disconnected in the meantime, the SessionImpl object will handle that properly.

@alex254 @villgust Can you look at this and accept this if you are OK?